### PR TITLE
Improve Docker setup with user permissions and docker-compose

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,79 @@
+# Docker Setup for Gallant Lab Website
+
+This repository includes Docker configuration to run the Jekyll site in a containerized environment, avoiding the need to install Ruby and Jekyll dependencies locally.
+
+## Quick Start
+
+The easiest way to run the site with Docker:
+
+```bash
+./docker-run.sh
+```
+
+This script automatically configures user permissions and starts the development server at http://localhost:8080.
+
+## Manual Docker Commands
+
+### Using Docker Compose
+
+Set environment variables for proper file permissions:
+
+```bash
+export DOCKER_UID=$(id -u)
+export DOCKER_GID=$(id -g)
+export DOCKER_USER=$(id -un)
+export DOCKER_GROUP=$(id -gn)
+docker compose up
+```
+
+### Building the Image Manually
+
+To build the Docker image from scratch:
+
+```bash
+# Build with current user permissions
+docker build \
+  --build-arg USERID=$(id -u) \
+  --build-arg GROUPID=$(id -g) \
+  --build-arg USERNAME=$(id -un) \
+  --build-arg GROUPNAME=$(id -gn) \
+  -t gallant-lab-site .
+
+# Run the built image
+docker run -p 8080:8080 -p 35729:35729 -v $(pwd):/srv/jekyll gallant-lab-site
+```
+
+## Troubleshooting
+
+### Permission Issues
+
+If you encounter permission errors like:
+```
+Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
+```
+
+Ensure you're using the user permissions setup either via `./docker-run.sh` or by setting the environment variables manually.
+
+### Bundle Dependencies
+
+The container will automatically manage bundle dependencies. If you see bundle-related errors, try rebuilding the image:
+
+```bash
+docker compose build --no-cache
+```
+
+## Configuration
+
+The Docker setup uses:
+- **Port 8080**: Jekyll development server
+- **Port 35729**: LiveReload for automatic browser refresh
+- **Volume mount**: Current directory mounted to `/srv/jekyll` in container
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOCKER_UID` | 1000 | User ID for container user |
+| `DOCKER_GID` | 1000 | Group ID for container user |
+| `DOCKER_USER` | jekyll | Username for container user |
+| `DOCKER_GROUP` | docker | Group name for container user |

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -48,6 +48,7 @@ docker run -p 8080:8080 -p 35729:35729 -v $(pwd):/srv/jekyll gallant-lab-site
 ### Permission Issues
 
 If you encounter permission errors like:
+
 ```
 Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
 ```
@@ -65,15 +66,16 @@ docker compose build --no-cache
 ## Configuration
 
 The Docker setup uses:
+
 - **Port 8080**: Jekyll development server
 - **Port 35729**: LiveReload for automatic browser refresh
 - **Volume mount**: Current directory mounted to `/srv/jekyll` in container
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DOCKER_UID` | 1000 | User ID for container user |
-| `DOCKER_GID` | 1000 | Group ID for container user |
-| `DOCKER_USER` | jekyll | Username for container user |
-| `DOCKER_GROUP` | docker | Group name for container user |
+| Variable       | Default | Description                   |
+| -------------- | ------- | ----------------------------- |
+| `DOCKER_UID`   | 1000    | User ID for container user    |
+| `DOCKER_GID`   | 1000    | Group ID for container user   |
+| `DOCKER_USER`  | jekyll  | Username for container user   |
+| `DOCKER_GROUP` | docker  | Group name for container user |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM ruby:slim
 
-# uncomment these if you are having this issue with the build:
-# /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll/site.rb:509:in `initialize': Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
-# ARG GROUPID=901
-# ARG GROUPNAME=ruby
-# ARG USERID=901
-# ARG USERNAME=jekyll
+ARG GROUPID=1000
+ARG GROUPNAME=docker
+ARG USERID=1000
+ARG USERNAME=jekyll
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -13,11 +11,9 @@ LABEL authors="Amir Pourmand,George Araújo" \
       description="Docker image for al-folio academic template" \
       maintainer="Amir Pourmand"
 
-# uncomment these if you are having this issue with the build:
-# /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll/site.rb:509:in `initialize': Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
 # add a non-root user to the image with a specific group and user id to avoid permission issues
-# RUN groupadd -r $GROUPNAME -g $GROUPID && \
-#     useradd -u $USERID -m -g $GROUPNAME $USERNAME
+RUN groupadd -r $GROUPNAME -g $GROUPID || true && \
+    useradd -u $USERID -m -g $GROUPNAME $USERNAME
 
 # install system dependencies
 RUN apt-get update -y && \
@@ -68,9 +64,8 @@ EXPOSE 8080
 
 COPY bin/entry_point.sh /tmp/entry_point.sh
 
-# uncomment this if you are having this issue with the build:
-# /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll/site.rb:509:in `initialize': Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
 # set the ownership of the jekyll site directory to the non-root user
-# USER $USERNAME
+RUN chown -R $USERNAME:$GROUPNAME /srv/jekyll
+USER $USERNAME
 
 CMD ["/tmp/entry_point.sh"]

--- a/_pages/people.md
+++ b/_pages/people.md
@@ -70,7 +70,7 @@ nav_order: 3
     <img src="{{ '/assets/img/people/Emily.Meschke.jpg' | relative_url }}" alt="Emily Meschke" class="img-fluid">
   </div>
   <div class="person-info">
-    <h3>Emily Meschke</h3>
+    <h3>Emily Meschke, PhD</h3>
     <div class="person-title">Postdoc</div>
     <div class="person-description">
       Areas of interest include development of new methods for recovering and interpreting brain networks.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # this file uses prebuilt image in dockerhub
 services:
   jekyll:
-    build: 
+    build:
       context: .
       args:
         GROUPID: ${DOCKER_GID:-1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,13 @@
 # this file uses prebuilt image in dockerhub
 services:
   jekyll:
-    image: amirpourmand/al-folio:v0.14.6
-    build: .
-    # uncomment these if you are having this issue with the build:
-    # /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll/site.rb:509:in `initialize': Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
-    # and fill the args values with the output of the commands on the right
-    # build:
-    #   args:
-    #     GROUPID: # id -g
-    #     GROUPNAME: # id -gn
-    #     USERID: # id -u
-    #     USERNAME: # echo $USER
+    build: 
+      context: .
+      args:
+        GROUPID: ${DOCKER_GID:-1000}
+        GROUPNAME: ${DOCKER_GROUP:-docker}
+        USERID: ${DOCKER_UID:-1000}
+        USERNAME: ${DOCKER_USER:-jekyll}
     ports:
       - 8080:8080
       - 35729:35729

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Set environment variables for Docker user permissions
+export DOCKER_UID=$(id -u)
+export DOCKER_GID=$(id -g)
+export DOCKER_USER=$(id -un)
+export DOCKER_GROUP=$(id -gn)
+
+echo "Starting Docker with:"
+echo "  User: $DOCKER_USER ($DOCKER_UID)"
+echo "  Group: $DOCKER_GROUP ($DOCKER_GID)"
+
+# Run docker compose with the environment variables
+docker compose up "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "working-gallant-site",
+  "name": "gallantlab.github.io",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## TL;DR

- Run `./docker-run.sh` to build the website locally
- Go to `localhost:8080` to see the website
- All changes will be automatically rendered locally before pushing
- This is useful to check changes before pushing (and waiting for the website to be published online)

## Summary

- Fixed Docker permission issues by implementing proper non-root user configuration
- Updated docker-compose.yml with build args for flexible user/group mapping
- Added comprehensive DOCKER.md documentation
- Created docker-run.sh convenience script for easy development workflow

## Benefits of Docker Compose Setup

This Docker Compose configuration enables developers to:

- **Local Website Inspection**: Run the Jekyll site locally at `http://localhost:8080` for immediate preview of changes
- **No Permission Issues**: Proper user/group mapping prevents file permission conflicts between host and container
- **Easy Development Workflow**: Single `docker-compose up` command starts the entire development environment
- **Consistent Environment**: Ensures all developers work with identical Ruby/Jekyll versions regardless of their local setup
- **Hot Reloading**: LiveReload functionality allows real-time preview of changes without manual refresh

## Test Plan

- [x] Verify Docker builds without permission errors
- [x] Test `docker-compose up` starts Jekyll server successfully
- [x] Confirm website accessible at localhost:8080
- [x] Validate file changes trigger LiveReload in browser
- [x] Test `docker-run.sh` convenience script works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)